### PR TITLE
Add custom, more verbose help message

### DIFF
--- a/bin/dataduct
+++ b/bin/dataduct
@@ -100,14 +100,43 @@ def visualize_database_actions(table_definitions, filename):
     database.visualize(filename)
 
 
+class _HelpAction(argparse._HelpAction):
+    """HelpAction class used to render a custom help message
+    """
+    def __call__(self, parser, namespace, values, option_string=None):
+        parser.print_help()
+        print ''
+
+        # retrieve subparsers from parser
+        subparsers_actions = [
+            action for action in parser._actions
+            if isinstance(action, argparse._SubParsersAction)]
+
+        for subparsers_action in subparsers_actions:
+            # get all subparsers and print help
+            for choice, subparser in subparsers_action.choices.items():
+                print "Command '{}'".format(choice)
+                print subparser.format_usage()
+
+        parser.exit()
+
+
 def main():
     """Main function"""
-    parser = argparse.ArgumentParser(description='Run Dataduct commands')
+    parser = argparse.ArgumentParser(description='Run Dataduct commands',
+                                     add_help=False)
     parser.add_argument(
         '-m',
         '--mode',
         default=None,
         help='Mode to run the pipeline and config overrides to use',
+    )
+    # Overwrite default help
+    parser.add_argument(
+        '-h',
+        '--help',
+        action=_HelpAction,
+        help='Show this help message and exit',
     )
     subparsers = parser.add_subparsers(help='Commands', dest='command')
 


### PR DESCRIPTION
```
➜  dataduct git:(develop) ✗ bin/dataduct -h
usage: dataduct [-m MODE] [-h] {config,pipeline,database,visualize} ...

Run Dataduct commands

positional arguments:
  {config,pipeline,database,visualize}
                        Commands

optional arguments:
  -m MODE, --mode MODE  Mode to run the pipeline and config overrides to use
  -h, --help            Show this help message and exit

Command 'config'
usage: dataduct config [-h] [-f FILENAME] {sync_from_s3,sync_to_s3}

Command 'pipeline'
usage: dataduct pipeline [-h] [-f] [-d DELAY]
                         {create,activate,validate} load_definitions
                         [load_definitions ...]

Command 'database'
usage: dataduct database [-h]
                         {recreate,create,drop,grant} table_definitions
                         [table_definitions ...]

Command 'visualize'
usage: dataduct visualize [-h] {pipeline,database} ...
```