### PR TITLE
Supported primaryKeys, createTableSql, commandOptions properties for load-redshift step

### DIFF
--- a/dataduct/pipeline/redshift_node.py
+++ b/dataduct/pipeline/redshift_node.py
@@ -16,7 +16,9 @@ class RedshiftNode(PipelineObject):
                  schedule,
                  redshift_database,
                  schema_name,
-                 table_name):
+                 table_name,
+                 create_table_sql,
+                 primary_keys):
         """Constructor for the RedshiftNode class
 
         Args:
@@ -25,6 +27,8 @@ class RedshiftNode(PipelineObject):
             redshift_database(RedshiftDatabase): database for the node
             schema_name(str): schema for node to extract or load data
             table_name(str): table for node to extract or load data
+            create_table_sql(str): Default value of table schema for node to extract or load data
+            primary_keys(str): primary keys for node to extract or load data
         """
 
         # Validate inputs
@@ -39,6 +43,8 @@ class RedshiftNode(PipelineObject):
             database=redshift_database,
             schemaName=schema_name,
             tableName=table_name,
+            createTableSql=create_table_sql,
+            primaryKeys=primary_keys,
         )
 
     @property

--- a/dataduct/steps/load_redshift.py
+++ b/dataduct/steps/load_redshift.py
@@ -17,6 +17,9 @@ class LoadRedshiftStep(ETLStep):
                  insert_mode="TRUNCATE",
                  max_errors=None,
                  replace_invalid_char=None,
+                 primary_keys=None,
+                 create_table_sql=None,
+                 command_options=None,
                  **kwargs):
         """Constructor for the LoadRedshiftStep class
 
@@ -27,6 +30,8 @@ class LoadRedshiftStep(ETLStep):
             redshift_database(RedshiftDatabase): database to excute the query
             max_errors(int): Maximum number of errors to be ignored during load
             replace_invalid_char(char): char to replace not utf-8 with
+            primary_keys(str): primary keys for redshift node
+            create_table_sql(str): Default value of table schema for redshift node
             **kwargs(optional): Keyword arguments directly passed to base class
         """
         super(LoadRedshiftStep, self).__init__(**kwargs)
@@ -38,10 +43,13 @@ class LoadRedshiftStep(ETLStep):
             redshift_database=redshift_database,
             schema_name=schema,
             table_name=table,
+            create_table_sql=create_table_sql,
+            primary_keys=primary_keys,
         )
 
-        command_options = ["DELIMITER '\t' ESCAPE TRUNCATECOLUMNS"]
-        command_options.append("NULL AS 'NULL' ")
+        if command_options is None:
+            command_options = ["DELIMITER '\t' ESCAPE TRUNCATECOLUMNS", "NULL AS 'NULL' "]
+
         if max_errors:
             command_options.append('MAXERROR %d' % int(max_errors))
         if replace_invalid_char:


### PR DESCRIPTION
If insert_mode is "KEEP_EXISTING" or "OVERWRITE_EXISTING", it does not work[1]. I wrote some code to support some options for this case.

```
-   step_type: load-redshift
    input_node: extract-s3-test
    schema: public
    table: test
    insert_mode: KEEP_EXISTING
    primary_keys: id
    command_options: [
        "gzip",
        "delimiter '\t'"
      ]
```

[1] http://docs.aws.amazon.com/datapipeline/latest/DeveloperGuide/dp-object-redshiftcopyactivity.html