### PR TITLE
Remove travis caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 python:
   - 2.7
 
-cache: pip
 sudo: false
 
 addons:


### PR DESCRIPTION
Travis caching actually makes the build slower