### PR TITLE
Expanded command options on create-load-redshift step

### DIFF
--- a/dataduct/steps/scripts/create_load_redshift_runner.py
+++ b/dataduct/steps/scripts/create_load_redshift_runner.py
@@ -11,7 +11,7 @@ from dataduct.database import Table
 
 
 def load_redshift(table, input_paths, max_error=0,
-                  replace_invalid_char=None, no_escape=False, gzip=False):
+                  replace_invalid_char=None, no_escape=False, gzip=False, command_options=None):
     """Load redshift table with the data in the input s3 paths
     """
     table_name = table.full_name
@@ -34,17 +34,27 @@ def load_redshift(table, input_paths, max_error=0,
     query = [delete_statement]
 
     for input_path in input_paths:
-        statement = (
-            "COPY {table} FROM '{path}' WITH CREDENTIALS AS '{creds}' "
-            "DELIMITER '\t' {escape} {gzip} NULL AS 'NULL' TRUNCATECOLUMNS "
-            "{max_error} {invalid_char_str};"
-        ).format(table=table_name,
-                 path=input_path,
-                 creds=creds,
-                 escape='ESCAPE' if not no_escape else '',
-                 gzip='GZIP' if gzip else '',
-                 max_error=error_string,
-                 invalid_char_str=invalid_char_str)
+        if command_options:
+            statement = (
+                "COPY {table} FROM '{path}' WITH CREDENTIALS AS '{creds}' "
+                "{command_options};"
+            ).format(table=table_name,
+                     path=input_path,
+                     creds=creds,
+                     command_options=command_options)
+        else:
+            statement = (
+                "COPY {table} FROM '{path}' WITH CREDENTIALS AS '{creds}' "
+                "DELIMITER '\t' {escape} {gzip} NULL AS 'NULL' TRUNCATECOLUMNS "
+                "{max_error} {invalid_char_str};"
+            ).format(table=table_name,
+                     path=input_path,
+                     creds=creds,
+                     escape='ESCAPE' if not no_escape else '',
+                     gzip='GZIP' if gzip else '',
+                     max_error=error_string,
+                     invalid_char_str=invalid_char_str)
+
         query.append(statement)
     return ' '.join(query)
 
@@ -60,6 +70,7 @@ def main():
                         default=None)
     parser.add_argument('--no_escape', action='store_true', default=False)
     parser.add_argument('--gzip', action='store_true', default=False)
+    parser.add_argument('--command_options', dest='command_options', default=None)
     parser.add_argument('--s3_input_paths', dest='input_paths', nargs='+')
     args = parser.parse_args()
     print args
@@ -75,8 +86,8 @@ def main():
     # Load data into redshift
     load_query = load_redshift(table, args.input_paths, args.max_error,
                                args.replace_invalid_char, args.no_escape,
-                               args.gzip)
-
+                               args.gzip, args.command_options)
+    print load_query
     cursor.execute(load_query)
     cursor.execute('COMMIT')
     cursor.close()


### PR DESCRIPTION
If you want to override copy command options, this change is useful.

```
-   step_type: create-load-redshift
    table_definition: test.sql
    script_arguments:
    - --command_options=maxerror as 2 csv quote as '\"' ACCEPTINVCHARS dateformat 'auto' timeformat 'auto' gzip
```