### PR TITLE
Ec2resource vpc options

### DIFF
--- a/dataduct/pipeline/ec2_resource.py
+++ b/dataduct/pipeline/ec2_resource.py
@@ -16,6 +16,8 @@ RESOURCE_ROLE = config.etl['RESOURCE_ROLE']
 INSTANCE_TYPE = config.ec2.get('INSTANCE_TYPE', const.M1_LARGE)
 ETL_AMI = config.ec2.get('ETL_AMI', const.NONE)
 SECURITY_GROUP = config.ec2.get('SECURITY_GROUP', const.NONE)
+SECURITY_GROUP_ID = config.ec2.get('SECURITY_GROUP_ID', const.NONE)
+SUBNET_ID = config.ec2.get('SUBNET_ID', const.NONE)
 KEY_PAIR = config.etl.get('KEY_PAIR', const.NONE)
 RETRY_DELAY = config.etl.get('RETRY_DELAY', const.DEFAULT_DELAY)
 
@@ -32,6 +34,8 @@ class Ec2Resource(PipelineObject):
                  instance_type=INSTANCE_TYPE,
                  ami=ETL_AMI,
                  security_group=SECURITY_GROUP,
+                 security_group_id=SECURITY_GROUP_ID,
+                 subnet_id=SUBNET_ID,
                  **kwargs):
         """Constructor for the Ec2Resource class
 
@@ -66,5 +70,7 @@ class Ec2Resource(PipelineObject):
             resourceRole=RESOURCE_ROLE,
             keyPair=KEY_PAIR,
             retryDelay=RETRY_DELAY,
-            securityGroups=security_group
+            securityGroups=security_group,
+            securityGroupIds=security_group_id,
+            subnetId=subnet_id
         )


### PR DESCRIPTION
Added the ability to pass in securityGroupIds and subnetId to EC2Resource to enable VPC launching the EC2 resource in a non-default VPC as described here: http://docs.aws.amazon.com/datapipeline/latest/DeveloperGuide/dp-object-ec2resource.html

Tested on our own pipeline.