### PR TITLE
disable automatic analyze and compression for create-load-redshift step

### DIFF
--- a/dataduct/steps/scripts/create_load_redshift_runner.py
+++ b/dataduct/steps/scripts/create_load_redshift_runner.py
@@ -33,8 +33,10 @@ def load_redshift(table, input_paths, max_error=0,
 
     query = [delete_statement]
 
-    template = \
-        "COPY {table} FROM '{path}' WITH CREDENTIALS AS '{creds}' {options};"
+    template = (
+        "COPY {table} FROM '{path}' WITH CREDENTIALS AS '{creds}' {options} "
+        "COMPUPDATE OFF STATUPDATE OFF;"
+    )
 
     for input_path in input_paths:
         if not command_options:

--- a/dataduct/steps/scripts/create_load_redshift_runner.py
+++ b/dataduct/steps/scripts/create_load_redshift_runner.py
@@ -34,15 +34,15 @@ def load_redshift(table, input_paths, max_error=0,
     query = [delete_statement]
 
     template = (
-        "COPY {table} FROM '{path}' WITH CREDENTIALS AS '{creds}' {options} "
-        "COMPUPDATE OFF STATUPDATE OFF;"
+        "COPY {table} FROM '{path}' WITH CREDENTIALS AS '{creds}' "
+        "COMPUPDATE OFF STATUPDATE OFF {options};"
     )
 
     for input_path in input_paths:
         if not command_options:
             command_options = (
                 "DELIMITER '\t' {escape} {gzip} NULL AS 'NULL' TRUNCATECOLUMNS "
-                "{max_error} {invalid_char_str};"
+                "{max_error} {invalid_char_str}"
             ).format(escape='ESCAPE' if not no_escape else '',
                      gzip='GZIP' if gzip else '',
                      max_error=error_string,


### PR DESCRIPTION
Reading the docs at http://docs.aws.amazon.com/redshift/latest/dg/copy-parameters-data-load.html#copy-comprows
it doesn't ever make sense we want to automatically ANALYZE tables, nor do automatic compression, as we first load into staging.

If you think this would be better off as a parameter flag, I can do that too.