### PR TITLE
fix duplicate primary check to not return 1 row per duplicate

### DIFF
--- a/dataduct/database/table.py
+++ b/dataduct/database/table.py
@@ -205,11 +205,13 @@ class Table(Relation):
         """
         pk_columns = comma_seperated(self.primary_key_names)
         sql = """
-            SELECT {pk_columns}
-                ,COUNT(1) duplicate_count
-            FROM {table_name}
-            GROUP BY {pk_columns}
-            HAVING COUNT(1) > 1
+            SELECT COUNT(1) duplicate_count
+            FROM (
+                SELECT 1
+                FROM {table_name}
+                GROUP BY {pk_columns}
+                HAVING COUNT(1) > 1
+            )
         """.format(table_name=self.full_name,
                    pk_columns=pk_columns)
 

--- a/dataduct/steps/scripts/primary_key_test.py
+++ b/dataduct/steps/scripts/primary_key_test.py
@@ -28,7 +28,8 @@ def main():
     connection = redshift_connection()
     table = Table(SqlScript(args.table))
     result = pdsql.read_sql(table.select_duplicates_script().sql(), connection)
-    check = PrimaryKeyCheck(len(result), name=args.test_name,
+    assert len(result) == 1, "primary key check script must return 1 row"
+    check = PrimaryKeyCheck(result.iloc[0].duplicate_count, name=args.test_name,
                             sns_topic_arn=args.sns_topic_arn)
     check.publish(args.log_to_s3, table=table.full_name,
                   path_suffix=args.path_suffix)


### PR DESCRIPTION
Currently the duplicate primary key check returns 1 row per duplicated primary key. For large tables, this can make the script go OOM and throw a non-helpful 'Script returned with exit status 137' rerror.

This change makes the primary key check script only return a single row containing the count of total duplicate primary keys.