### PR TITLE
Ensure LOG_DIR default path is valid

### DIFF
--- a/dataduct/config/logger_config.py
+++ b/dataduct/config/logger_config.py
@@ -22,7 +22,7 @@ def logger_configuration():
         raise Exception('logging section is missing in config')
 
     log_directory = os.path.expanduser(config.logging.get(
-        'LOG_DIR', '~/' + CONFIG_DIR))
+        'LOG_DIR', os.path.join('~', CONFIG_DIR)))
     file_name = config.logging.get(
         'LOG_FILE', LOG_FILE)
 

--- a/dataduct/config/logger_config.py
+++ b/dataduct/config/logger_config.py
@@ -22,7 +22,7 @@ def logger_configuration():
         raise Exception('logging section is missing in config')
 
     log_directory = os.path.expanduser(config.logging.get(
-        'LOG_DIR', '~' + CONFIG_DIR))
+        'LOG_DIR', '~/' + CONFIG_DIR))
     file_name = config.logging.get(
         'LOG_FILE', LOG_FILE)
 


### PR DESCRIPTION
It appears as though the intended path for the LOG_DIR was not `./~.dataduct` but instead `~/.dataduct`.