### PR TITLE
Worker group support for dataduct steps

### DIFF
--- a/dataduct/pipeline/activity.py
+++ b/dataduct/pipeline/activity.py
@@ -3,13 +3,16 @@ Base class for data pipeline instance
 """
 
 from .pipeline_object import PipelineObject
+from ..utils.helpers import exactly_one
+from ..utils.exceptions import ETLInputError
 
 
 class Activity(PipelineObject):
     """Base class for pipeline activities
     """
 
-    def __init__(self, dependsOn, maximumRetries, **kwargs):
+    def __init__(self, dependsOn, maximumRetries, runsOn,
+                 workerGroup, **kwargs):
         """Constructor for the activity class
 
         Args:
@@ -20,6 +23,14 @@ class Activity(PipelineObject):
         Note:
             dependsOn and maximum retries are required fields for any activity
         """
+        if not exactly_one(runsOn, workerGroup):
+            raise ETLInputError(
+                'Exactly one of runsOn or workerGroup allowed!')
+
+        if runsOn:
+            kwargs['runsOn'] = runsOn
+        else:
+            kwargs['workerGroup'] = workerGroup
         super(Activity, self).__init__(
             dependsOn=dependsOn,
             maximumRetries=maximumRetries,

--- a/dataduct/pipeline/copy_activity.py
+++ b/dataduct/pipeline/copy_activity.py
@@ -22,8 +22,9 @@ class CopyActivity(Activity):
                  id,
                  input_node,
                  output_node,
-                 resource,
                  schedule,
+                 resource=None,
+                 worker_group=None,
                  max_retries=None,
                  depends_on=None,
                  **kwargs):
@@ -33,8 +34,9 @@ class CopyActivity(Activity):
             id(str): id of the object
             input_node(S3Node / list of S3Nodes): input nodes for the activity
             output_node(S3Node / list of S3Nodes): output nodes for activity
-            resource(Ec2Resource / EmrResource): resource to run the activity on
             schedule(Schedule): schedule of the pipeline
+            resource(Ec2Resource / EmrResource): resource to run the activity on
+            worker_group(str): the worker group to run the activity on
             max_retries(int): number of retries for the activity
             depends_on(list of activities): dependendent pipelines steps
             **kwargs(optional): Keyword arguments directly passed to base class
@@ -60,5 +62,6 @@ class CopyActivity(Activity):
             input=input_node,
             output=output_node,
             runsOn=resource,
+            workerGroup=worker_group,
             schedule=schedule,
         )

--- a/dataduct/pipeline/emr_activity.py
+++ b/dataduct/pipeline/emr_activity.py
@@ -18,10 +18,11 @@ class EmrActivity(Activity):
 
     def __init__(self,
                  id,
-                 resource,
                  schedule,
                  input_node,
                  emr_step_string,
+                 resource=None,
+                 worker_group=None,
                  output_node=None,
                  additional_files=None,
                  max_retries=None,
@@ -30,9 +31,10 @@ class EmrActivity(Activity):
 
         Args:
             id(str): id of the object
-            resource(Ec2Resource / EMRResource): resource to run the activity on
             schedule(Schedule): schedule of the pipeline
             emr_step_string(list of str): command string to be executed
+            resource(Ec2Resource / EMRResource): resource to run the activity on
+            worker_group(str): the worker group to run the activity on
             output_node(S3Node): output_node for the emr job
             additional_files(list of S3File): Additional files required for emr
             max_retries(int): number of retries for the activity
@@ -56,6 +58,7 @@ class EmrActivity(Activity):
             maximumRetries=max_retries,
             dependsOn=depends_on,
             runsOn=resource,
+            workerGroup=worker_group,
             schedule=schedule,
             step=emr_step_string,
             output=output_node,

--- a/dataduct/pipeline/redshift_copy_activity.py
+++ b/dataduct/pipeline/redshift_copy_activity.py
@@ -20,11 +20,12 @@ class RedshiftCopyActivity(Activity):
 
     def __init__(self,
                  id,
-                 resource,
                  schedule,
                  input_node,
                  output_node,
                  insert_mode,
+                 resource=None,
+                 worker_group=None,
                  command_options=None,
                  max_retries=None,
                  depends_on=None):
@@ -32,10 +33,11 @@ class RedshiftCopyActivity(Activity):
 
         Args:
             id(str): id of the object
-            resource(Ec2Resource / EMRResource): resource to run the activity on
             schedule(Schedule): schedule of the pipeline
             input_node(S3Node / RedshiftNode): input data node
             output_node(S3Node / RedshiftNode): output data node
+            resource(Ec2Resource / EMRResource): resource to run the activity on
+            worker_group(str): the worker group to run the activity on
             command_options(list of str): command options for the activity
             max_retries(int): number of retries for the activity
             depends_on(list of activities): dependendent pipelines steps
@@ -60,6 +62,7 @@ class RedshiftCopyActivity(Activity):
             'input': input_node,
             'output': output_node,
             'runsOn': resource,
+            'workerGroup': worker_group,
             'insertMode': insert_mode,
             'schedule': schedule,
             'dependsOn': depends_on,

--- a/dataduct/pipeline/shell_command_activity.py
+++ b/dataduct/pipeline/shell_command_activity.py
@@ -21,8 +21,9 @@ class ShellCommandActivity(Activity):
                  id,
                  input_node,
                  output_node,
-                 resource,
                  schedule,
+                 resource=None,
+                 worker_group=None,
                  script_uri=None,
                  script_arguments=None,
                  command=None,
@@ -35,8 +36,9 @@ class ShellCommandActivity(Activity):
             id(str): id of the object
             input_node(S3Node / list of S3Nodes): input nodes for the activity
             output_node(S3Node / list of S3Nodes): output nodes for activity
-            resource(Ec2Resource / EMRResource): resource to run the activity on
             schedule(Schedule): schedule of the pipeline
+            resource(Ec2Resource / EMRResource): resource to run the activity on
+            worker_group(str): the worker group to run the activity on
             script_uri(S3File): s3 uri of the script
             script_arguments(list of str): command line arguments to the script
             command(str): command to be run as shell activity
@@ -71,6 +73,7 @@ class ShellCommandActivity(Activity):
             input=input_node,
             output=output_node,
             runsOn=resource,
+            workerGroup=worker_group,
             schedule=schedule,
             scriptUri=script_uri,
             scriptArgument=script_arguments,

--- a/dataduct/pipeline/sql_activity.py
+++ b/dataduct/pipeline/sql_activity.py
@@ -20,10 +20,11 @@ class SqlActivity(Activity):
 
     def __init__(self,
                  id,
-                 resource,
                  schedule,
                  script,
                  database,
+                 resource=None,
+                 worker_group=None,
                  script_arguments=None,
                  queue=None,
                  max_retries=None,
@@ -32,11 +33,11 @@ class SqlActivity(Activity):
 
         Args:
             id(str): id of the object
-            resource(Ec2Resource / EMRResource): resource to run the activity on
             schedule(Schedule): schedule of the pipeline
             script(S3File): s3 uri of the script
-            script_arguments(list of str): command line arguments to the script
             database(RedshiftDatabase): database to execute commands on
+            resource(Ec2Resource / EMRResource): resource to run the activity on
+            worker_group(str): the worker group to run the activity on
             queue(str): queue in which the query should be executed
             max_retries(int): number of retries for the activity
             depends_on(list of activities): dependendent pipelines steps
@@ -63,6 +64,7 @@ class SqlActivity(Activity):
             maximumRetries=max_retries,
             dependsOn=depends_on,
             runsOn=resource,
+            workerGroup=worker_group,
             schedule=schedule,
             scriptUri=script,
             scriptArgument=script_arguments,

--- a/dataduct/steps/create_load_redshift.py
+++ b/dataduct/steps/create_load_redshift.py
@@ -59,5 +59,5 @@ class CreateAndLoadStep(TransformStep):
             step_args(dict): Dictionary of the step arguments for the class
         """
         step_args = cls.base_arguments_processor(etl, input_args)
-        step_args['resource'] = etl.ec2_resource
+
         return step_args

--- a/dataduct/steps/create_update_sql.py
+++ b/dataduct/steps/create_update_sql.py
@@ -78,5 +78,5 @@ class CreateUpdateSqlStep(TransformStep):
         """
         step_args = cls.base_arguments_processor(etl, input_args)
         cls.pop_inputs(step_args)
-        step_args['resource'] = etl.ec2_resource
+
         return step_args

--- a/dataduct/steps/emr_job.py
+++ b/dataduct/steps/emr_job.py
@@ -3,6 +3,7 @@ ETL step wrapper for EmrActivity can be executed on EMR Cluster
 """
 from .etl_step import ETLStep
 from ..pipeline import EmrActivity
+from ..utils import constants as const
 
 
 class EMRJobStep(ETLStep):
@@ -27,6 +28,7 @@ class EMRJobStep(ETLStep):
         self.activity = self.create_pipeline_object(
             object_class=EmrActivity,
             resource=self.resource,
+            worker_group=self.worker_group,
             input_node=self.input,
             schedule=self.schedule,
             emr_step_string=step_string,
@@ -43,7 +45,7 @@ class EMRJobStep(ETLStep):
             etl(ETLPipeline): Pipeline object containing resources and steps
             step_args(dict): Dictionary of the step arguments for the class
         """
-        step_args = cls.base_arguments_processor(etl, input_args)
-        step_args['resource'] = etl.emr_cluster
+        step_args = cls.base_arguments_processor(
+            etl, input_args, resource_type=const.EMR_CLUSTER_STR)
 
         return step_args

--- a/dataduct/steps/emr_streaming.py
+++ b/dataduct/steps/emr_streaming.py
@@ -4,6 +4,7 @@ ETL step wrapper for EmrStreamingActivity can be executed on EMR Cluster
 from .etl_step import ETLStep
 from ..pipeline import EmrActivity
 from ..s3 import S3File
+from ..utils import constants as const
 
 HADOOP_1_SERIES = ['1', '2']
 
@@ -111,6 +112,7 @@ class EMRStreamingStep(ETLStep):
         self.activity = self.create_pipeline_object(
             object_class=EmrActivity,
             resource=self.resource,
+            worker_group=self.worker_group,
             input_node=self.input,
             schedule=self.schedule,
             emr_step_string=step_string,
@@ -128,7 +130,7 @@ class EMRStreamingStep(ETLStep):
             etl(ETLPipeline): Pipeline object containing resources and steps
             step_args(dict): Dictionary of the step arguments for the class
         """
-        step_args = cls.base_arguments_processor(etl, input_args)
-        step_args['resource'] = etl.emr_cluster
+        step_args = cls.base_arguments_processor(
+            etl, input_args, resource_type=const.EMR_CLUSTER_STR)
 
         return step_args

--- a/dataduct/steps/etl_step.py
+++ b/dataduct/steps/etl_step.py
@@ -18,7 +18,7 @@ MAX_RETRIES = config.etl.get('MAX_RETRIES', const.ZERO)
 class ETLStep(object):
     """ETL step class with activities and metadata.
 
-    An ETL Step is an abstraction over the set of each database object. It
+    An ETL Step is an abstraction over a unit of work. It
     represents a chunk of objects having the following attributes:
 
     -  input
@@ -32,8 +32,8 @@ class ETLStep(object):
 
     def __init__(self, id, s3_data_dir=None, s3_log_dir=None,
                  s3_source_dir=None, schedule=None, resource=None,
-                 input_node=None, input_path=None, required_steps=None,
-                 max_retries=MAX_RETRIES, sns_object=None):
+                 worker_group=None, input_node=None, input_path=None,
+                 required_steps=None, max_retries=MAX_RETRIES, sns_object=None):
         """Constructor for the ETLStep object
 
         Args:
@@ -52,6 +52,7 @@ class ETLStep(object):
         self.s3_source_dir = s3_source_dir
         self.schedule = schedule
         self.resource = resource
+        self.worker_group = worker_group
         self.max_retries = max_retries
         self._depends_on = list()
         self._output = None
@@ -101,7 +102,7 @@ class ETLStep(object):
         for step in required_steps:
             self._required_activities.extend(step.activities)
 
-        # Set required_acitivites as depend_on variable of all activities
+        # Set required_activities as the depend_on variable of all activities
         for activity in self.activities:
             activity['dependsOn'] = self._find_actual_required_activities()
 
@@ -268,6 +269,7 @@ class ETLStep(object):
             CopyActivity,
             schedule=self.schedule,
             resource=self.resource,
+            worker_group=self.worker_group,
             input_node=new_input_node,
             output_node=output_node,
             max_retries=self.max_retries
@@ -390,20 +392,41 @@ class ETLStep(object):
         return [x for x in self._objects.values() if isinstance(x, Activity)]
 
     @classmethod
-    def base_arguments_processor(cls, etl, input_args):
+    def base_arguments_processor(cls, etl, input_args,
+                                 resource_type=const.EC2_RESOURCE_STR):
         """Process the step arguments according to the ETL pipeline
 
         Args:
             etl(ETLPipeline): Pipeline object containing resources and steps
             input_args(dict): Dictionary of the step arguments from the YAML
+            resource_type(str): either const.EMR_CLUSTER_STR
+                or const.EC2_RESOURCE_STR
         """
+        assert (resource_type in [const.EMR_CLUSTER_STR,
+                                  const.EC2_RESOURCE_STR],
+                'resource type must be one of %s or %s' %
+                (const.EC2_RESOURCE_STR, const.EMR_CLUSTER_STR))
+        resource_or_worker_group = {}
+        if resource_type == const.EMR_CLUSTER_STR:
+            worker_group = config.emr.get('WORKER_GROUP', None)
+            if worker_group:
+                resource_or_worker_group['worker_group'] = worker_group
+            else:
+                resource_or_worker_group['resource'] = etl.emr
+        else:
+            worker_group = config.ec2.get('WORKER_GROUP', None)
+            if worker_group:
+                resource_or_worker_group['worker_group'] = worker_group
+            else:
+                resource_or_worker_group['resource'] = etl.ec2_resource
+
         # Base dictionary for every step
         step_args = {
-            'resource': None,
             'schedule': etl.schedule,
             'max_retries': etl.max_retries,
-            'required_steps': list()
+            'required_steps': list(),
         }
+        step_args.update(resource_or_worker_group)
         step_args.update(input_args)
 
         # Description is optional and should not be passed

--- a/dataduct/steps/extract_rds.py
+++ b/dataduct/steps/extract_rds.py
@@ -76,6 +76,7 @@ class ExtractRdsStep(ETLStep):
             object_class=CopyActivity,
             schedule=self.schedule,
             resource=self.resource,
+            worker_group=self.worker_group,
             input_node=input_node,
             output_node=intermediate_node,
             depends_on=self.depends_on,
@@ -101,6 +102,7 @@ class ExtractRdsStep(ETLStep):
             command=command,
             max_retries=self.max_retries,
             resource=self.resource,
+            worker_group=self.worker_group,
             schedule=self.schedule,
         )
 
@@ -114,6 +116,5 @@ class ExtractRdsStep(ETLStep):
         """
         input_args = cls.pop_inputs(input_args)
         step_args = cls.base_arguments_processor(etl, input_args)
-        step_args['resource'] = etl.ec2_resource
 
         return step_args

--- a/dataduct/steps/extract_redshift.py
+++ b/dataduct/steps/extract_redshift.py
@@ -47,6 +47,7 @@ class ExtractRedshiftStep(ETLStep):
             output_node=self.output,
             insert_mode=insert_mode,
             resource=self.resource,
+            worker_group=self.worker_group,
             schedule=self.schedule,
             depends_on=self.depends_on,
             command_options=["DELIMITER '\t' ESCAPE"],
@@ -63,6 +64,5 @@ class ExtractRedshiftStep(ETLStep):
         input_args = cls.pop_inputs(input_args)
         step_args = cls.base_arguments_processor(etl, input_args)
         step_args['redshift_database'] = etl.redshift_database
-        step_args['resource'] = etl.ec2_resource
 
         return step_args

--- a/dataduct/steps/extract_s3.py
+++ b/dataduct/steps/extract_s3.py
@@ -44,5 +44,6 @@ class ExtractS3Step(ETLStep):
         input_args = cls.pop_inputs(input_args)
         step_args = cls.base_arguments_processor(etl, input_args)
         step_args.pop('resource')
+        step_args.pop('worker_group')
 
         return step_args

--- a/dataduct/steps/load_redshift.py
+++ b/dataduct/steps/load_redshift.py
@@ -55,6 +55,7 @@ class LoadRedshiftStep(ETLStep):
             output_node=self.output,
             insert_mode=insert_mode,
             resource=self.resource,
+            worker_group=self.worker_group,
             schedule=self.schedule,
             depends_on=self.depends_on,
             command_options=command_options,
@@ -70,6 +71,5 @@ class LoadRedshiftStep(ETLStep):
         """
         step_args = cls.base_arguments_processor(etl, input_args)
         step_args['redshift_database'] = etl.redshift_database
-        step_args['resource'] = etl.ec2_resource
 
         return step_args

--- a/dataduct/steps/load_reload_pk.py
+++ b/dataduct/steps/load_reload_pk.py
@@ -85,6 +85,7 @@ class LoadReloadAndPrimaryKeyStep(ETLStep):
             input_node=None,
             output_node=None,
             resource=self.resource,
+            worker_group=self.worker_group,
             schedule=self.schedule,
             script_uri=script,
             script_arguments=script_arguments,
@@ -129,6 +130,7 @@ class LoadReloadAndPrimaryKeyStep(ETLStep):
             input_node=None,
             output_node=None,
             resource=self.resource,
+            worker_group=self.worker_group,
             schedule=self.schedule,
             script_uri=script,
             script_arguments=script_arguments,
@@ -165,6 +167,7 @@ class LoadReloadAndPrimaryKeyStep(ETLStep):
             input_node=None,
             output_node=None,
             resource=self.resource,
+            worker_group=self.worker_group,
             schedule=self.schedule,
             script_uri=script,
             script_arguments=script_arguments,
@@ -192,6 +195,6 @@ class LoadReloadAndPrimaryKeyStep(ETLStep):
             step_args(dict): Dictionary of the step arguments for the class
         """
         step_args = cls.base_arguments_processor(etl, input_args)
-        step_args['resource'] = etl.ec2_resource
         step_args['pipeline_name'] = etl.name
+
         return step_args

--- a/dataduct/steps/pipeline_dependencies.py
+++ b/dataduct/steps/pipeline_dependencies.py
@@ -96,7 +96,6 @@ class PipelineDependenciesStep(TransformStep):
         """
         input_args = cls.pop_inputs(input_args)
         step_args = cls.base_arguments_processor(etl, input_args)
-        step_args['resource'] = etl.ec2_resource
         step_args['pipeline_name'] = etl.name
 
         return step_args

--- a/dataduct/steps/qa_transform.py
+++ b/dataduct/steps/qa_transform.py
@@ -52,6 +52,5 @@ class QATransformStep(TransformStep):
         input_args = cls.pop_inputs(input_args)
         step_args = cls.base_arguments_processor(etl, input_args)
         step_args['pipeline_name'] = etl.name
-        step_args['resource'] = etl.ec2_resource
 
         return step_args

--- a/dataduct/steps/sql_command.py
+++ b/dataduct/steps/sql_command.py
@@ -62,6 +62,7 @@ class SqlCommandStep(ETLStep):
             object_class=SqlActivity,
             max_retries=self.max_retries,
             resource=self.resource,
+            worker_group=self.worker_group,
             schedule=self.schedule,
             database=redshift_database,
             script_arguments=script_arguments,
@@ -81,5 +82,5 @@ class SqlCommandStep(ETLStep):
         input_args = cls.pop_inputs(input_args)
         step_args = cls.base_arguments_processor(etl, input_args)
         step_args['redshift_database'] = etl.redshift_database
-        step_args['resource'] = etl.ec2_resource
+
         return step_args

--- a/dataduct/steps/transform.py
+++ b/dataduct/steps/transform.py
@@ -117,6 +117,7 @@ class TransformStep(ETLStep):
             input_node=input_nodes,
             output_node=output_node,
             resource=self.resource,
+            worker_group=self.worker_group,
             schedule=self.schedule,
             script_uri=script,
             script_arguments=script_arguments,
@@ -175,10 +176,11 @@ class TransformStep(ETLStep):
             etl(ETLPipeline): Pipeline object containing resources and steps
             step_args(dict): Dictionary of the step arguments for the class
         """
-        step_args = cls.base_arguments_processor(etl, input_args)
-        if step_args.pop('resource_type', None) == const.EMR_CLUSTER_STR:
-            step_args['resource'] = etl.emr_cluster
+        if input_args.pop('resource_type', None) == const.EMR_CLUSTER_STR:
+            resource_type = const.EMR_CLUSTER_STR
         else:
-            step_args['resource'] = etl.ec2_resource
+            resource_type = const.EC2_RESOURCE_STR
+        step_args = cls.base_arguments_processor(
+            etl, input_args, resource_type=resource_type)
 
         return step_args

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -103,6 +103,11 @@ executed.
 EC2
 ~~~
 
+Either Datapipeline can be used for instance management, or you can use an existing
+Worker Group. Worker groups have priority over Datapipeline instance management.
+
+Using Datapipeline for instance management:
+
 ::
 
     ec2:
@@ -114,8 +119,20 @@ The ec2 config controls the configuration for the ec2-resource started
 by the datapipeline. You can override these with ``ec2_resouce_config``
 in your pipeline definition for specific pipelines.
 
+Using Worker Groups:
+
+::
+
+    ec2:
+        WORKER_GROUP: MY_EC2_WORKER_GROUP_NAME
+
 EMR
 ~~~
+
+Either Datapipeline can be used for cluster management, or you can use an existing
+Worker Group. Worker groups have priority over Datapipeline cluster management.
+
+Using Datapipeline for cluster management:
 
 ::
 
@@ -133,6 +150,13 @@ EMR
 
 The emr config controls the configuration for the emr-resource started
 by the datapipeline.
+
+Using Worker Groups:
+
+::
+
+    emr:
+        WORKER_GROUP: MY_EMR_WORKER_GROUP_NAME
 
 ETL
 ~~~


### PR DESCRIPTION
Add support for worker groups, specified via configs.

Currently we do not allow a mixed workflow where some steps are ran via worker groups, while others are ran via Datapipeline instance/cluster management. This can be added in if required. 