### PR TITLE
hotfix for file_name not existing

### DIFF
--- a/dataduct/s3/utils.py
+++ b/dataduct/s3/utils.py
@@ -59,7 +59,10 @@ def upload_to_s3(s3_path, file_name=None, file_text=None):
     if not any([file_name, file_text]):
         raise ETLInputError('File_name or text should be given')
 
-    source_size = os.stat(file_name).st_size
+    if file_name:
+        source_size = os.stat(file_name).st_size
+    else:
+        source_size = len(file_text)
     if source_size > CHUNK_SIZE:
         bar = pyprind.ProgPercent(
             PROGRESS_SECTIONS, monitor=True, title='Uploading %s' % file_name)


### PR DESCRIPTION
file_name may not exist, leading to error
    source_size = os.stat(file_name).st_size
TypeError: coercing to Unicode: need string or buffer, NoneType found
