### PR TITLE
Change get_aws_credentials_from_file to load in the same order that boto does.

### DIFF
--- a/dataduct/config/credentials.py
+++ b/dataduct/config/credentials.py
@@ -43,7 +43,7 @@ def get_aws_credentials_from_iam():
 def get_aws_credentials_from_file(filename=None):
     """Get the AWS credentials from boto config files
 
-    Tries to load from the specified filename, if applicable, then follows what
+    Tries to load from the specified filename, if applicable, else follows what
     boto does by following the order specified at
     http://boto.cloudhackers.com/en/latest/boto_config_tut.html#details
     """

--- a/dataduct/config/credentials.py
+++ b/dataduct/config/credentials.py
@@ -41,7 +41,11 @@ def get_aws_credentials_from_iam():
 
 
 def get_aws_credentials_from_file(filename=None):
-    """Get the aws from credential files
+    """Get the AWS credentials from boto config files
+
+    Tries to load from the specified filename, if applicable, then follows what
+    boto does by following the order specified at
+    http://boto.cloudhackers.com/en/latest/boto_config_tut.html#details
     """
     config = SafeConfigParser()
     cred_file = None
@@ -49,10 +53,10 @@ def get_aws_credentials_from_file(filename=None):
         cred_file = filename
     elif os.path.isfile('/etc/boto.cfg'):
         cred_file = '/etc/boto.cfg'
-    elif os.path.isfile(os.path.expanduser('~/.boto')):
-        cred_file = os.path.expanduser('~/.boto')
     elif os.path.isfile(os.path.expanduser('~/.aws/credentials')):
         cred_file = os.path.expanduser('~/.aws/credentials')
+    elif os.path.isfile(os.path.expanduser('~/.boto')):
+        cred_file = os.path.expanduser('~/.boto')
     else:
         raise Exception("Cannot find a credentials file")
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -23,7 +23,7 @@ The major dependencies of dataduct are:
 -  ``testfixtures``
 
 Ensure that a `boto config file <http://boto.cloudhackers.com/en/latest/boto_config_tut.html>`__
-containing your AWS credentials is present.
+containing proper AWS credentials is present.
 
 The visualizations are created using:
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -22,6 +22,9 @@ The major dependencies of dataduct are:
 -  ``pyparsing``
 -  ``testfixtures``
 
+Ensure that a `boto config file <http://boto.cloudhackers.com/en/latest/boto_config_tut.html>`__
+containing your AWS credentials is present.
+
 The visualizations are created using:
 
 -  ``graphviz``


### PR DESCRIPTION
Additionally, add documentation so that users know they need a boto config file with credentials.

Fixes #206?
