### PR TITLE
fixed create_pipeline_object call in extract_postgres.py to match ini…

### DIFF
--- a/dataduct/steps/extract_postgres.py
+++ b/dataduct/steps/extract_postgres.py
@@ -69,7 +69,8 @@ class ExtractPostgresStep(ETLStep):
             table=table,
             username=user,
             password=password,
-            sql=sql,
+            select_query=sql,
+            insert_query=None,
             host=rds_instance_id,
         )
 


### PR DESCRIPTION
Fixed issue mentioned in #218 
Once fix is applied the pip version can be updated

The call extract_postgres.py:65 `self.create_pipeline_object`didn't match the method signature of the init in postgres_node.py

was using
        `sql=sql`
instead of
            `select_query=sql,
            insert_query=None,`
