### PR TITLE
issue 222 - redshift config params are not being sent to open_psql_shell

### DIFF
--- a/dataduct/utils/cli.py
+++ b/dataduct/utils/cli.py
@@ -81,7 +81,7 @@ def open_sql_shell(database_type, host_alias=None, **kwargs):
     from dataduct.config import Config
     config = Config()
     if database_type == 'redshift':
-        open_shell.open_psql_shell()
+        open_shell.open_psql_shell(config.redshift)
     else:
         assert config.mysql.get(host_alias), \
             'host_alias "{}" does not exist in config'.format(host_alias)


### PR DESCRIPTION
comes up when using `dataduct sql_shell redshift`. Error message (currently) is 

> TypeError: open_psql_shell() takes exactly 1 argument (0 given)

added the redshift configs. All tests pass locally. Did not add a test for this directly as I could not find any tests for this particular module.

Additionally, I opened the PR against develop, as it appears to be more up to date than master. If I need to switch it to master let me know!
