### PR TITLE
initial support for Shell Command Activity to support a s3 precondition

### DIFF
--- a/dataduct/pipeline/precondition.py
+++ b/dataduct/pipeline/precondition.py
@@ -12,6 +12,7 @@ class Precondition(PipelineObject):
     def __init__(self,
                  id,
                  is_directory=True,
+                 s3Prefix=None,
                  **kwargs):
         """Constructor for the Precondition class
 
@@ -25,11 +26,11 @@ class Precondition(PipelineObject):
             super(Precondition, self).__init__(
                 id=id,
                 type='S3PrefixNotEmpty',
-                s3Prefix="#{node.directoryPath}",
+                s3Prefix=s3Prefix if s3Prefix is not None else "#{node.directoryPath}",
             )
         else:
             super(Precondition, self).__init__(
                 id=id,
                 type='S3KeyExists',
-                s3Prefix="#{node.filePath}",
+                s3Prefix=s3Prefix if s3Prefix is not None else "#{node.filePath}",
             )

--- a/dataduct/pipeline/shell_command_activity.py
+++ b/dataduct/pipeline/shell_command_activity.py
@@ -3,6 +3,7 @@ Pipeline object class for ShellCommandActivity
 """
 
 from .activity import Activity
+from .precondition import Precondition
 from ..config import Config
 from .schedule import Schedule
 from ..utils import constants as const
@@ -29,7 +30,8 @@ class ShellCommandActivity(Activity):
                  command=None,
                  max_retries=None,
                  depends_on=None,
-                 additional_s3_files=None):
+                 additional_s3_files=None,
+                 precondition=None):
         """Constructor for the ShellCommandActivity class
 
         Args:
@@ -55,6 +57,10 @@ class ShellCommandActivity(Activity):
         if command is not None and script_uri is not None:
             raise ETLInputError('command and script both can not be provided')
 
+        if precondition and not isinstance(precondition, Precondition):
+            raise ETLInputError(
+                    'Input precondition must be of the type Precondition')
+
         # Set default values
         if depends_on is None:
             depends_on = []
@@ -77,7 +83,8 @@ class ShellCommandActivity(Activity):
             schedule=schedule,
             scriptUri=script_uri,
             scriptArgument=script_arguments,
-            command=command
+            command=command,
+            precondition=precondition
         )
 
         # Add the additional s3 files


### PR DESCRIPTION
Minor change to allow preconditions within ShellCommandActivities (optional field, allowed per http://docs.aws.amazon.com/datapipeline/latest/DeveloperGuide/dp-object-shellcommandactivity.html). Also updates to Precondition to allow class instantiation with user-defined s3prefix.

I believe these are both "under the hood", non user facing changes. Couldn't find or think of any documentation required.
