### PR TITLE
Environment variables support in pipeline definition

### DIFF
--- a/dataduct/etl/etl_actions.py
+++ b/dataduct/etl/etl_actions.py
@@ -1,6 +1,8 @@
 """Script that parses the pipeline definition and has action functions
 """
+import os
 import yaml
+import re
 
 from ..pipeline import Activity
 from ..pipeline import MysqlNode
@@ -13,6 +15,15 @@ from .etl_pipeline import ETLPipeline
 
 import logging
 logger = logging.getLogger(__name__)
+
+
+def replace_env_vars(string):
+    match = re.search(r'%{(\w+)}', string, re.MULTILINE)
+    if match:
+        for env_name in match.groups():
+            string = string.replace('%{'+env_name+'}', os.getenv(env_name, ''))
+
+    return string
 
 
 def read_pipeline_definition(file_path):
@@ -34,7 +45,7 @@ def read_pipeline_definition(file_path):
     if extension not in ['yml', 'yaml']:
         raise ETLInputError('Pipeline definition should have a yml or yaml extention')
     with open(file_path) as f:
-        definition = yaml.load(f.read())
+        definition = yaml.load(replace_env_vars(f.read()))
 
         # remove the variables key from the pipeline definition
         # http://stackoverflow.com/questions/4150782/using-yaml-with-variables


### PR DESCRIPTION
Use environment variables in pipeline definition

Our initiatives to add this feature:
- reuse some scripts and control the behavior with environment variables. 
- not store credentials in the repo

For example. We need to copy files from FTP to S3 but different buckets depends on the file type. We created an generic script to do the copy and control the destination bucket with environment variable.

    -   step_type: transform
         name: copy_ftp_files
         script_name: copy_ftp_files.py
         script_directory: scripts
         script_arguments:
         -   --FTP_URL=<FTP_URL>
         -   --FTP_USERNAME=<FTP_USERNAME>
         -   --FTP_PASSWD=<FTP_PASSWD>
         -   --FILE_TYPE=<FILE_TYPE>
         -   --DEST_BUCKET=<DEST_BUCKET>
